### PR TITLE
Handle optional whitespace in X-Forwarded-For header

### DIFF
--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -102,6 +102,7 @@ def create_wsgi_request(
     if "," in x_forwarded_for:
         # The last one is the cloudfront proxy ip. The second to last is the real client ip.
         # Everything else is user supplied and untrustworthy.
+        x_forwarded_for = x_forwarded_for.replace(", ", ",")
         remote_addr = x_forwarded_for.split(", ")[-2]
     else:
         remote_addr = x_forwarded_for or "127.0.0.1"


### PR DESCRIPTION
<!--

Before you submit this PR, please make sure that you meet these criteria:

* Did you read the [contributing guide](https://github.com/zappa/Zappa/#contributing)?

* If this is a non-trivial commit, did you **open a ticket** for discussion?

* Did you **put the URL for that ticket in a comment** in the code?

* If you made a new function, did you **write a good docstring** for it?

* Did you avoid putting "_" in front of your new function for no reason?

* Did you write a test for your new code?

* Did the Travis build pass?

* Did you improve (or at least not significantly reduce)  the amount of code test coverage?

* Did you **make sure this code actually works on Lambda**, as well as locally?

* Did you test this code with all of **Python 3.6**, **Python 3.7** and **Python 3.8** ? 

* Does this commit ONLY relate to the issue at hand and have your linter shit all over the code?

If so, awesome! If not, please try to fix those issues before submitting your Pull Request.

Thank you for your contribution!

-->

## Description
Whitespace in X-Forwarded-For is optional and therefore should handle the case when there is no whitespace

## GitHub Issues
https://github.com/zappa/Zappa/issues/1127
