### PR TITLE
Handle optional space in x-forwarded-for header

### DIFF
--- a/zappa/wsgi.py
+++ b/zappa/wsgi.py
@@ -103,7 +103,7 @@ def create_wsgi_request(
         # The last one is the cloudfront proxy ip. The second to last is the real client ip.
         # Everything else is user supplied and untrustworthy.
         x_forwarded_for = x_forwarded_for.replace(", ", ",")
-        remote_addr = x_forwarded_for.split(", ")[-2]
+        remote_addr = x_forwarded_for.split(",")[-2]
     else:
         remote_addr = x_forwarded_for or "127.0.0.1"
 


### PR DESCRIPTION
Whitespace in X-Forwarded-For is optional and therefore should handle the case when there is no whitespace

